### PR TITLE
fix: Check semver before download release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,30 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v1
+        uses: asdf-vm/actions/plugin-test@v1.0.1
         with:
           command: spectral --version
+
+      - name: asdf_plugin_test_6_5_0
+        uses: asdf-vm/actions/plugin-test@v1.0.1
+        with:
+          command: spectral --version
+          version: 6.5.0
+
+      - name: asdf_plugin_test_6_6_0
+        uses: asdf-vm/actions/plugin-test@v1.0.1
+        with:
+          command: spectral --version
+          version: 6.6.0
+
+      - name: asdf_plugin_test_6_7_0
+        uses: asdf-vm/actions/plugin-test@v1.0.1
+        with:
+          command: spectral --version
+          version: 6.7.0
+
+      - name: asdf_plugin_test_6_11_1
+        uses: asdf-vm/actions/plugin-test@v1.0.1
+        with:
+          command: spectral --version
+          version: 6.11.1

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -34,7 +34,7 @@ list_all_versions() {
 }
 
 semVer() {
-  printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' ' ');
+  printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' ' ')
 }
 
 download_release() {
@@ -43,13 +43,13 @@ download_release() {
   filename="$2"
 
   case $(uname) in
-    #Linux OS
-    Linux)
-      platform="linux"
+  #Linux OS
+  Linux)
+    platform="linux"
     ;;
-    # Mac OS
-    Darwin)
-      platform="macos"
+  # Mac OS
+  Darwin)
+    platform="macos"
     ;;
   esac
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -33,22 +33,29 @@ list_all_versions() {
   list_github_tags
 }
 
+semVer() {
+  printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' ' ');
+}
+
 download_release() {
-  local version filename url
+  local version filename url platform
   version="$1"
   filename="$2"
 
-  case $(uname -sr) in
-
-  Linux*)
+  case $(uname) in
     #Linux OS
-    url="$GH_REPO/releases/download/v${version}/spectral-linux"
+    Linux)
+      platform="linux"
     ;;
-  Darwin*)
     # Mac OS
-    url="$GH_REPO/releases/download/v${version}/spectral-macos"
+    Darwin)
+      platform="macos"
     ;;
   esac
+
+  if [[ $(semVer $version) -gt $(semVer "6.6.0") ]]; then platform+="-x64"; fi
+
+  url="$GH_REPO/releases/download/v${version}/spectral-$platform"
 
   echo "* Downloading $TOOL_NAME release $version..."
   curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"


### PR DESCRIPTION
It is currently not possible to download newer versions of the spectral binary since v6.7 due to a filename convention changes.

This PR adds the needed changes to check if the installation version is newer than this change. If it is, then adds the architecture suffix to the filename, but if it isn't, sets only the platform name as is currently done.

This allows to download any version of the tool and solve this open issue #7 